### PR TITLE
Update set()_자료구조.md

### DIFF
--- a/modern_Javascript/set()_자료구조.md
+++ b/modern_Javascript/set()_자료구조.md
@@ -1,6 +1,6 @@
 # set() 자료구조 - 생성시 추가와 Spread(펼침) 연산자 출력
 
-## [1]: 생성시 값을 추가하는 방법
+## 1. 생성시 값을 추가하는 방법
 
 ```
 let ar = new Set().add('X').add('Y)
@@ -18,7 +18,7 @@ console.log(ar); // X, Y, A, B, C
 console.log(ar.size); // 5
 ```
 
-## [2]: 출력 —> Spread 연산자 사용 —> 이터러블 객체(Iterable Object)의 요소를 하나씩 분리하여 전개 —> 펼침 연산자
+## 2. 출력 —> Spread 연산자 사용 —> 이터러블 객체(Iterable Object)의 요소를 하나씩 분리하여 전개 —> 펼침 연산자
 
 ```xml
 let testArr = ['k', 'o', 'r', 'e', 'a'];


### PR DESCRIPTION
마크다운에서는 `[~]` 는 다른 의미를 갖습니다. 링크 문법의 일부입니다. https://opentutorials.org/module/782/6083
그리고 굳이 대괄호로 숫자를 구분해줄 필요는 없을 것 같네요. 
개인적으로는 숫자를 없애는것도 나쁘진 않을 것 같습니다.